### PR TITLE
Enforce extending to the same position type only

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,7 +5,6 @@
 * Join AFV freqs with sectors to show online.
 * Fix the on the ground altitude maths
 * Make light theme AD parts darker
-* Add implementation for TMA extensions (Coral & Tasmania)
 * Markers and labels are too small on the ground.
 * Query OSM via Overpass API for aeroway=parking_position
 // Get aerodrome polygon

--- a/TODO.md
+++ b/TODO.md
@@ -5,6 +5,7 @@
 * Join AFV freqs with sectors to show online.
 * Fix the on the ground altitude maths
 * Make light theme AD parts darker
+* Add implementation for TMA extensions (Coral & Tasmania)
 * Markers and labels are too small on the ground.
 * Query OSM via Overpass API for aeroway=parking_position
 // Get aerodrome polygon

--- a/atc.js
+++ b/atc.js
@@ -300,7 +300,7 @@ export async function getOnlinePositions() {
         activeFrequencies.forEach(function(activeFrequency) {
             // Get all the sectors that use that frequency (but only the same position type as the primary position).
             var frequencySectors = sectors.filter(sector => sector.Frequency == activeFrequency
-                && sector.Callsign.toUpperCase().endsWith(onlineController.callsign.toUpperCase().slice(-3)));
+                && sector.volumes.length > 0 && sector.Callsign.toUpperCase().endsWith(onlineController.callsign.toUpperCase().slice(-3)));
             // If nothing found, continue.
             if (!frequencySectors) return;
             var extendedSector;

--- a/atc.js
+++ b/atc.js
@@ -295,12 +295,12 @@ export async function getOnlinePositions() {
             activeFrequencies.push(convertedFrequency);
         });
         // if only 1 frequency, nothing else to do.
-        if (activeFrequencies.length <= 1 || !sector.Callsign.toUpperCase().includes("CTR")) return;
+        if (activeFrequencies.length <= 1) return;
         // 
         activeFrequencies.forEach(function(activeFrequency) {
-            // Get all the sectors that use that frequency (but only CTR).
+            // Get all the sectors that use that frequency (but only the same position type as the primary position).
             var frequencySectors = sectors.filter(sector => sector.Frequency == activeFrequency
-                && sector.Callsign.toUpperCase().includes("CTR"));
+                && sector.Callsign.toUpperCase().endsWith(onlineController.callsign.toUpperCase().slice(-3)));
             // If nothing found, continue.
             if (!frequencySectors) return;
             var extendedSector;

--- a/atc.js
+++ b/atc.js
@@ -247,7 +247,7 @@ export async function getOnlineControllers(){
            return;
         }
         // Check if they are controller for the right region.
-        if (!sectors.some(sector => sector.Callsign == controller.callsign.toUpperCase())) 
+        if (!sectors.some(sector => sector.Callsign == controller.callsign.toUpperCase()))
         {
             return;
         }
@@ -295,7 +295,7 @@ export async function getOnlinePositions() {
             activeFrequencies.push(convertedFrequency);
         });
         // if only 1 frequency, nothing else to do.
-        if (activeFrequencies.length <= 1) return;
+        if (activeFrequencies.length <= 1 || !sector.Callsign.toUpperCase().includes("CTR")) return;
         // 
         activeFrequencies.forEach(function(activeFrequency) {
             // Get all the sectors that use that frequency (but only CTR).


### PR DESCRIPTION
Also allows TMA to extend for instances like Coral & Tasmania TCU. Fixes instances where TMA and ENR share the same frequency (DN_DEP and BN-BUR_CTR, RK_APP and ML-ELW_CTR, probably more..)